### PR TITLE
[ADP-21] Add test_calculator.py for test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.DS_Store

--- a/test_calculator.py
+++ b/test_calculator.py
@@ -1,0 +1,6 @@
+from calculator import add
+from unittest.mock import patch
+
+@patch('builtins.input', side_effect=['10', '20'])
+def test_add(mock_input):
+    assert add() == 30


### PR DESCRIPTION
加算の関数をテストするためにtest_calculator.pyを追加。
calculator.pyの中にテストを記載すると可読性が低下すると考え、別にテスト用のファイルを作成しました。
unittest.mock.patchを使用して、ユーザーのインプットを模擬しています。
test_addの例だと、最初のinputに'10'、次のinputに'20'が入るようになっています。
これまで学習した時と同様に`pytest`とターミナルで入力してもらえればテストが開始します。

また、テストを実行すると余分なファイルが作成されるためgitに入れないように.gitignoreも追加。